### PR TITLE
feat: add /tools/ section with 4 SEO-targeted interactive tools

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -202,6 +202,9 @@ export default function HomePage() {
                 <div className="flex items-baseline gap-3 mb-8">
                     <span className="font-display text-4xl sm:text-5xl font-bold text-zinc-800">04</span>
                     <span className="font-display text-sm font-bold uppercase tracking-wider text-white">Supported Schemes</span>
+                    <a href="/tools/url-scheme-registry/" className="ml-auto font-mono text-[10px] uppercase tracking-widest text-emerald-600 hover:text-emerald-400 transition-colors">
+                        See all 50+ schemes →
+                    </a>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-px bg-zinc-800">
                     {[

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -1,6 +1,13 @@
 export default function sitemap() {
     const baseUrl = 'https://www.shortlink.studio'
 
+    const tools = [
+        'url-compatibility-checker',
+        'deep-link-builder',
+        'markdown-link-generator',
+        'url-scheme-registry',
+    ]
+
     return [
         {
             url: baseUrl,
@@ -20,5 +27,17 @@ export default function sitemap() {
             changeFrequency: 'yearly',
             priority: 0.5,
         },
+        {
+            url: `${baseUrl}/tools`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.9,
+        },
+        ...tools.map(slug => ({
+            url: `${baseUrl}/tools/${slug}`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.8,
+        })),
     ]
 }

--- a/app/tools/deep-link-builder/page.js
+++ b/app/tools/deep-link-builder/page.js
@@ -1,0 +1,147 @@
+import ToolShell from 'components/tools/tool-shell'
+import Faq from 'components/tools/faq'
+import GeoGrid from 'components/tools/geo-grid'
+import BuilderClient from 'components/tools/builder-client'
+
+export const metadata = {
+    title: 'Deep Link Builder',
+    description: 'Generate Slack, Obsidian, Zoom, Notion, and Figma deep links from a guided form. Outputs both the raw scheme:// URL and a universal HTTPS Shortlink.',
+    alternates: { canonical: '/tools/deep-link-builder' },
+    openGraph: {
+        title: 'Deep Link Builder — Shortlink',
+        description: 'Generate Slack, Obsidian, Zoom, Notion, and Figma deep links.',
+        url: 'https://www.shortlink.studio/tools/deep-link-builder',
+        images: ['/preview.png'],
+    },
+}
+
+const FAQ_ITEMS = [
+    {
+        q: 'How do I create a deep link to a Slack channel?',
+        a: 'Slack channel deep links use the format slack://channel?team={team_id}&id={channel_id}. The team ID starts with T (e.g. T0001), and the channel ID starts with C. You can find both in the URL when you open Slack in a browser, or by right-clicking a channel and selecting Copy link.',
+    },
+    {
+        q: 'What is the Obsidian URI scheme?',
+        a: 'Obsidian uses the obsidian:// scheme. The most common format is obsidian://open?vault={vault_name}&file={note_path} to open a specific note. Advanced URI plugin extends this with obsidian://advanced-uri for jumping to headings, blocks, or running commands. Both formats work across macOS, Windows, Linux, iOS, and Android.',
+    },
+    {
+        q: 'How do I make a clickable Zoom link in Notion?',
+        a: 'The native zoommtg:// scheme is stripped by Notion. Two options work: paste the standard https://zoom.us/j/{meeting_id} URL (opens in browser, then app), or use this builder to generate a zoommtg:// link, wrap it in a Shortlink, and paste the Shortlink into Notion. Both render as clickable links.',
+    },
+    {
+        q: 'What is a Figma deep link?',
+        a: 'Figma deep links use the figma:// scheme to open a file directly in the desktop app. The format is figma://file/{file_key}/{file_name} where the file key is the alphanumeric ID from the Figma URL (figma.com/file/<key>/...). Add ?node-id=<id> to open at a specific frame.',
+    },
+    {
+        q: 'How do I get a Notion page ID?',
+        a: 'Open the page in Notion and copy its URL. The page ID is the 32-character alphanumeric string at the end (e.g. notion.so/Page-Title-abc123def456...). The deep link format is notion://www.notion.so/{page-id}. This builder extracts the ID automatically when you paste the full URL.',
+    },
+]
+
+const FORMAT_REFERENCE = [
+    { app: 'Slack', format: 'slack://channel?team={team_id}&id={channel_id}', notes: 'Add &message={ts} to deep-link to a specific message.' },
+    { app: 'Obsidian', format: 'obsidian://open?vault={vault}&file={note_path}', notes: 'URL-encode the path. Add #{heading} for a specific heading.' },
+    { app: 'Zoom', format: 'zoommtg://zoom.us/join?action=join&confno={meeting_id}', notes: 'Optional &pwd={passcode}. The newer zoomus:// scheme is also accepted.' },
+    { app: 'Notion', format: 'notion://www.notion.so/{page_id}', notes: 'Page ID is the 32-character alphanumeric suffix from the page URL.' },
+    { app: 'Figma', format: 'figma://file/{file_key}/{name}', notes: 'Add ?node-id={id} to open at a specific frame.' },
+    { app: 'Linear', format: 'linear://issue/{TEAM-123}', notes: 'Identifier matches the issue key shown in the Linear UI.' },
+    { app: 'VS Code', format: 'vscode://file/{absolute_path}:{line}:{col}', notes: 'Line and column are optional but useful for code reviews.' },
+]
+
+export default function DeepLinkBuilderPage() {
+    const webAppLd = {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        name: 'Deep Link Builder',
+        url: 'https://www.shortlink.studio/tools/deep-link-builder/',
+        applicationCategory: 'UtilitiesApplication',
+        operatingSystem: 'Any',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        description: metadata.description,
+        featureList: [
+            'Guided forms for Slack, Obsidian, Zoom, Notion, Figma deep links',
+            'Auto-extracts Notion page IDs from full URLs',
+            'Generates both raw scheme:// and HTTPS Shortlink output',
+            'Stateless: runs entirely in the browser',
+        ],
+    }
+
+    return (
+        <ToolShell
+            slug="deep-link-builder"
+            eyebrow="Generator"
+            title="Deep Link Builder"
+            intro="Build correctly formatted slack://, obsidian://, zoom://, notion://, and figma:// deep links from a guided form. Get both the raw scheme URL and a universal HTTPS Shortlink that works in tools that strip custom schemes."
+        >
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
+            />
+
+            {/* Builder */}
+            <section className="py-10">
+                <BuilderClient />
+            </section>
+
+            {/* What is a deep link */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    What is a deep link?
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    A deep link is a URL that opens a specific view inside a desktop or mobile app rather than landing on a generic homepage. Custom URL schemes like <code className="font-mono text-sm text-zinc-300">slack://</code>, <code className="font-mono text-sm text-zinc-300">obsidian://</code>, and <code className="font-mono text-sm text-zinc-300">notion://</code> are how apps register themselves with the operating system to handle their own links.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    The catch: while the OS knows how to open these schemes, most content platforms (Notion, Confluence, Gmail, GitHub) refuse to render them as clickable links. Wrap the deep link in an HTTPS URL via <a href="/" className="text-emerald-500 hover:text-emerald-400">Shortlink</a> and it works everywhere.
+                </p>
+            </section>
+
+            {/* Format reference */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Deep link formats by app
+                </h2>
+                <p className="text-zinc-500 text-sm mb-6 max-w-[60ch]">
+                    Reference for the most-used custom URL schemes. Use the builder above to generate any of these without hand-crafting the URL.
+                </p>
+                <div className="overflow-x-auto border border-zinc-800">
+                    <table className="w-full font-mono text-xs">
+                        <thead>
+                            <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
+                                <th className="text-left p-3 border-b border-zinc-800">App</th>
+                                <th className="text-left p-3 border-b border-zinc-800">Format</th>
+                                <th className="text-left p-3 border-b border-zinc-800 hidden md:table-cell">Notes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {FORMAT_REFERENCE.map(row => (
+                                <tr key={row.app} className="border-b border-zinc-900">
+                                    <td className="p-3 text-white">{row.app}</td>
+                                    <td className="p-3 text-emerald-500 break-all">{row.format}</td>
+                                    <td className="p-3 text-zinc-500 hidden md:table-cell">{row.notes}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            {/* Why wrap in HTTPS */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Why wrap deep links in HTTPS?
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    Custom scheme URLs only render as clickable when the platform that displays them allows non-standard schemes. Notion, Gmail, GitHub, Linear, and most enterprise wikis don’t. Wrapping the deep link in an HTTPS URL solves this without changing the destination.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    Shortlink encodes the original scheme URL into the path of an <code className="font-mono text-sm text-zinc-300">https://shortlink.studio/...</code> URL using stateless LZ compression. The wrapped link works in any context that allows HTTPS links; clicking it triggers a client-side redirect to the original scheme URL, which the OS hands off to the registered app.
+                </p>
+            </section>
+
+            <GeoGrid heading="How teams use deep links by region" />
+
+            <Faq items={FAQ_ITEMS} />
+        </ToolShell>
+    )
+}

--- a/app/tools/layout.js
+++ b/app/tools/layout.js
@@ -1,0 +1,10 @@
+export const metadata = {
+    title: {
+        template: '%s | Shortlink Tools',
+        default: 'Tools',
+    },
+}
+
+export default function ToolsLayout({ children }) {
+    return children
+}

--- a/app/tools/markdown-link-generator/page.js
+++ b/app/tools/markdown-link-generator/page.js
@@ -1,0 +1,137 @@
+import ToolShell from 'components/tools/tool-shell'
+import Faq from 'components/tools/faq'
+import GeoGrid from 'components/tools/geo-grid'
+import MarkdownClient from 'components/tools/markdown-client'
+
+export const metadata = {
+    title: 'Markdown Link Generator',
+    description: 'Format any URL into Markdown, Slack mrkdwn, HTML, Obsidian wikilink, or plain link syntax. Auto-wraps custom scheme URLs into universal Shortlinks.',
+    alternates: { canonical: '/tools/markdown-link-generator' },
+    openGraph: {
+        title: 'Markdown Link Generator — Shortlink',
+        description: 'Format URLs for Notion, Obsidian, Slack, HTML, and more.',
+        url: 'https://www.shortlink.studio/tools/markdown-link-generator',
+        images: ['/preview.png'],
+    },
+}
+
+const FAQ_ITEMS = [
+    {
+        q: 'How do I format a link in Notion?',
+        a: 'Notion uses standard CommonMark Markdown for links: [Label](https://example.com). Type the link, select it, press Cmd/Ctrl+K, then paste the URL. Or paste a URL onto selected text and Notion auto-formats it. Custom scheme URLs (slack://, obsidian://) are stripped — wrap them in a Shortlink first.',
+    },
+    {
+        q: 'What is Slack mrkdwn link syntax?',
+        a: 'Slack uses its own mrkdwn flavor: <https://example.com|Label>. Note the angle brackets and the pipe (not parentheses or square brackets). You can also paste a bare URL and Slack auto-links it. Custom schemes other than slack:// are not auto-linked.',
+    },
+    {
+        q: 'How do I make a clickable link in Obsidian?',
+        a: 'Obsidian supports two formats: standard Markdown ([Label](url)) for any link, and wikilinks ([[Note Name|Label]]) for internal vault notes. Wikilinks are designed for in-vault navigation; for external URLs always use the Markdown format. Custom schemes work in both if Obsidian is set to allow them.',
+    },
+    {
+        q: 'Markdown link syntax cheat sheet',
+        a: 'Inline: [Label](https://example.com). Reference: [Label][ref] then [ref]: https://example.com elsewhere. Auto-link: <https://example.com>. With title: [Label](https://example.com "Hover text"). All four work in CommonMark, GitHub Flavored Markdown, Notion, Obsidian, and most other Markdown renderers.',
+    },
+    {
+        q: 'How do I embed a Zoom link in a Notion page?',
+        a: 'Use [Join meeting](https://zoom.us/j/123456789) for the standard HTTPS form. For the native zoommtg:// scheme — which Notion strips — wrap it in a Shortlink first, then paste [Join meeting](https://shortlink.studio/s/...) into Notion. The wrapped link renders as clickable and still opens the Zoom desktop app.',
+    },
+]
+
+const SYNTAX_REFERENCE = [
+    { surface: 'Markdown / CommonMark', syntax: '[Label](url)', notes: 'Standard everywhere — Notion, Bear, Logseq, GitHub, GitLab, Jekyll, Hugo.' },
+    { surface: 'Notion', syntax: '[Label](url)', notes: 'Same as Markdown. Cmd/Ctrl+K to insert quickly.' },
+    { surface: 'Obsidian (external)', syntax: '[Label](url)', notes: 'Use Markdown for external URLs. Wikilinks are for in-vault navigation.' },
+    { surface: 'Obsidian (vault note)', syntax: '[[Note Name|Label]]', notes: 'Resolves internal note paths only.' },
+    { surface: 'Slack mrkdwn', syntax: '<url|Label>', notes: 'Angle brackets, pipe separator. No parentheses.' },
+    { surface: 'HTML', syntax: '<a href="url">Label</a>', notes: 'For email signatures, raw HTML, web pages.' },
+    { surface: 'reStructuredText', syntax: '`Label <url>`_', notes: 'Sphinx docs, Python projects, ReadTheDocs.' },
+    { surface: 'AsciiDoc', syntax: 'url[Label]', notes: 'Antora, AsciiDoctor — note no separator between url and brackets.' },
+    { surface: 'BBCode', syntax: '[url=...]Label[/url]', notes: 'Older forums, phpBB, vBulletin.' },
+    { surface: 'Auto-link (bare URL)', syntax: 'https://example.com', notes: 'Slack, Discord, Twitter, GitHub comments — auto-detect URLs.' },
+]
+
+export default function MarkdownLinkGeneratorPage() {
+    const webAppLd = {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        name: 'Markdown Link Generator',
+        url: 'https://www.shortlink.studio/tools/markdown-link-generator/',
+        applicationCategory: 'UtilitiesApplication',
+        operatingSystem: 'Any',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        description: metadata.description,
+        featureList: [
+            'Outputs Markdown, Slack mrkdwn, HTML, Obsidian wikilink, RST, plain URL',
+            'Detects custom URL schemes and offers Shortlink wrapping',
+            'One-click copy per format',
+            'Stateless: no server calls, no tracking',
+        ],
+    }
+
+    return (
+        <ToolShell
+            slug="markdown-link-generator"
+            eyebrow="Formatter"
+            title="Markdown Link Generator"
+            intro="Type a URL and a label once, get every link format you need: Markdown, Slack mrkdwn, HTML, Obsidian wikilinks, reStructuredText, and plain. Custom scheme URLs auto-detect and offer one-toggle Shortlink wrapping."
+        >
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
+            />
+
+            {/* Generator */}
+            <section className="py-10">
+                <MarkdownClient />
+            </section>
+
+            {/* Syntax reference */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Link syntax by platform
+                </h2>
+                <p className="text-zinc-500 text-sm mb-6 max-w-[60ch]">
+                    Reference table for the most-used link formats. The generator above produces correctly formatted output for every row.
+                </p>
+                <div className="overflow-x-auto border border-zinc-800">
+                    <table className="w-full font-mono text-xs">
+                        <thead>
+                            <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
+                                <th className="text-left p-3 border-b border-zinc-800">Surface</th>
+                                <th className="text-left p-3 border-b border-zinc-800">Syntax</th>
+                                <th className="text-left p-3 border-b border-zinc-800 hidden md:table-cell">Notes</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {SYNTAX_REFERENCE.map(row => (
+                                <tr key={row.surface} className="border-b border-zinc-900">
+                                    <td className="p-3 text-white">{row.surface}</td>
+                                    <td className="p-3 text-emerald-500 break-all">{row.syntax}</td>
+                                    <td className="p-3 text-zinc-500 hidden md:table-cell">{row.notes}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            {/* Why custom schemes need wrapping */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Why custom scheme URLs need wrapping first
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    Markdown link syntax is universal: <code className="font-mono text-sm text-zinc-300">[Label](url)</code> renders the same way in every Markdown processor. The variable is what the surrounding platform allows in the URL slot.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    Most platforms whitelist a small set of schemes — typically <code className="font-mono text-sm text-zinc-300">https</code>, <code className="font-mono text-sm text-zinc-300">http</code>, <code className="font-mono text-sm text-zinc-300">mailto</code>, sometimes <code className="font-mono text-sm text-zinc-300">tel</code>. Anything else (slack://, obsidian://, zoommtg://) gets stripped before the link is rendered. The generator above auto-detects this case and offers to wrap the URL in a <a href="/" className="text-emerald-500 hover:text-emerald-400">Shortlink</a> so the resulting Markdown renders as clickable everywhere.
+                </p>
+            </section>
+
+            <GeoGrid heading="Where teams paste these formats" />
+
+            <Faq items={FAQ_ITEMS} />
+        </ToolShell>
+    )
+}

--- a/app/tools/page.js
+++ b/app/tools/page.js
@@ -1,0 +1,91 @@
+import Header from 'components/header'
+import Footer from 'components/footer'
+import { ALL_TOOLS } from 'components/tools/tool-shell'
+
+export const metadata = {
+    title: 'Tools',
+    description: 'Free interactive tools for working with custom scheme URLs and deep links: compatibility checker, deep link builder, markdown link generator, and a registry of every app URL scheme.',
+    alternates: {
+        canonical: '/tools',
+    },
+    openGraph: {
+        title: 'Shortlink Tools — Deep Link & URL Scheme Utilities',
+        description: 'Free interactive tools for working with custom scheme URLs and deep links.',
+        url: 'https://www.shortlink.studio/tools',
+        images: ['/preview.png'],
+    },
+}
+
+export default function ToolsIndex() {
+    const jsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: 'Shortlink Tools',
+        url: 'https://www.shortlink.studio/tools',
+        description: metadata.description,
+        hasPart: ALL_TOOLS.map(t => ({
+            '@type': 'WebApplication',
+            name: t.name,
+            url: `https://www.shortlink.studio/tools/${t.slug}/`,
+            description: t.tagline,
+            applicationCategory: 'UtilitiesApplication',
+            operatingSystem: 'Any',
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        })),
+    }
+
+    return (
+        <main className="min-h-[100dvh] flex flex-col">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+            />
+            <Header />
+
+            <div className="flex-1 max-w-5xl mx-auto w-full px-5">
+                {/* Breadcrumb */}
+                <nav aria-label="Breadcrumb" className="pt-8 sm:pt-10">
+                    <ol className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                        <li><a href="/" className="hover:text-emerald-500 transition-colors">Home</a></li>
+                        <li className="text-zinc-700">/</li>
+                        <li className="text-zinc-300">Tools</li>
+                    </ol>
+                </nav>
+
+                <header className="pt-6 pb-10 border-b border-zinc-800">
+                    <h1 className="font-display text-4xl sm:text-5xl md:text-6xl tracking-tighter leading-[0.95] font-bold text-white">
+                        Tools
+                    </h1>
+                    <p className="text-zinc-400 leading-relaxed max-w-[60ch] mt-5">
+                        Free, stateless utilities for working with custom URL schemes and deep links.
+                        Each tool runs entirely in your browser — no signup, no tracking, no server calls.
+                    </p>
+                </header>
+
+                <section className="py-10">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-zinc-800">
+                        {ALL_TOOLS.map(t => (
+                            <a
+                                key={t.slug}
+                                href={`/tools/${t.slug}/`}
+                                className="bg-zinc-950 p-6 sm:p-8 hover:bg-zinc-900 transition-colors block group"
+                            >
+                                <div className="font-display text-xl sm:text-2xl font-bold text-white mb-2 group-hover:text-emerald-400 transition-colors">
+                                    {t.name}
+                                </div>
+                                <p className="text-zinc-500 text-sm leading-relaxed">
+                                    {t.tagline}
+                                </p>
+                                <div className="mt-4 font-mono text-[10px] uppercase tracking-widest text-emerald-600">
+                                    Open tool →
+                                </div>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+            </div>
+
+            <Footer />
+        </main>
+    )
+}

--- a/app/tools/url-compatibility-checker/page.js
+++ b/app/tools/url-compatibility-checker/page.js
@@ -1,0 +1,188 @@
+import ToolShell from 'components/tools/tool-shell'
+import Faq from 'components/tools/faq'
+import GeoGrid from 'components/tools/geo-grid'
+import CheckerClient from 'components/tools/checker-client'
+import { PLATFORMS, check } from 'utils/data/platform-rules'
+import { URL_SCHEMES } from 'utils/data/url-schemes'
+
+export const metadata = {
+    title: 'URL Compatibility Checker',
+    description: 'Check whether a custom scheme URL works in Notion, Slack, Obsidian, Gmail, GitHub, and other platforms. Paste any link and see exactly where it breaks.',
+    alternates: { canonical: '/tools/url-compatibility-checker' },
+    openGraph: {
+        title: 'URL Compatibility Checker — Shortlink',
+        description: 'Check whether a custom scheme URL works in Notion, Slack, Obsidian, and other platforms.',
+        url: 'https://www.shortlink.studio/tools/url-compatibility-checker',
+        images: ['/preview.png'],
+    },
+}
+
+const FAQ_ITEMS = [
+    {
+        q: 'Why is my Slack link broken in Notion?',
+        a: 'Notion sanitizes pasted URLs and only renders standard HTTP(S), mailto, and tel links. The slack:// scheme is stripped before the link is rendered, so it shows up as plain text. Wrap the slack:// URL in a Shortlink (https://shortlink.studio/...) and Notion will render it as a clickable link that still opens Slack.',
+    },
+    {
+        q: 'Does Obsidian support custom scheme URLs?',
+        a: 'Obsidian renders https://, http://, mailto:, and its own obsidian:// scheme natively. Most other custom schemes (slack://, zoom://, figma://) render as plain text or are blocked. To embed a non-Obsidian deep link, wrap it in a Shortlink first.',
+    },
+    {
+        q: 'Can you embed a Zoom link in a Notion page?',
+        a: 'A standard https://zoom.us/j/... link works in Notion and opens the meeting in the browser or app. The native zoommtg:// scheme does NOT work — Notion strips it. Use either the HTTPS Zoom URL or a Shortlink-wrapped zoommtg:// URL.',
+    },
+    {
+        q: 'What URLs work in Slack messages?',
+        a: 'Slack auto-links HTTPS, HTTP, mailto, tel, and its own slack:// scheme. Other custom schemes (obsidian://, notion://, figma://) render as plain text. Wrap them in a Shortlink and they become clickable in any Slack message.',
+    },
+    {
+        q: 'How do I fix deep links in email clients?',
+        a: 'Most email clients (Gmail, Outlook web, Apple Mail) only render HTTPS, HTTP, mailto, and tel links. Custom schemes are stripped or rendered as plain text. The reliable fix is to wrap the custom scheme URL in an HTTPS link via Shortlink — recipients click the HTTPS link and get redirected to the app.',
+    },
+]
+
+// Build a static reference matrix: for every well-known scheme × every platform.
+// Pure server render — this is the SEO payload that crawlers index even
+// without JavaScript.
+function buildMatrix() {
+    const popular = ['slack', 'obsidian', 'zoommtg', 'notion', 'figma', 'vscode', 'linear', 'msteams', 'mailto']
+    const rows = popular.map(prefix => {
+        const meta = URL_SCHEMES.find(s => s.scheme.startsWith(prefix + '://') || s.scheme.startsWith(prefix + ':'))
+        return {
+            scheme: prefix,
+            display: meta ? meta.scheme : prefix + '://',
+            cells: PLATFORMS.map(p => check(prefix, p)),
+        }
+    })
+    return rows
+}
+
+export default function UrlCompatibilityCheckerPage() {
+    const matrix = buildMatrix()
+
+    const webAppLd = {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        name: 'URL Compatibility Checker',
+        url: 'https://www.shortlink.studio/tools/url-compatibility-checker/',
+        applicationCategory: 'UtilitiesApplication',
+        operatingSystem: 'Any',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        description: metadata.description,
+        featureList: [
+            'Detects URL scheme from any pasted link',
+            'Shows compatibility across 9 major platforms',
+            'Per-platform explanation of why links break',
+            'Direct fix path via Shortlink wrapper',
+        ],
+    }
+
+    const symbol = (status) => {
+        if (status === 'works') return { mark: '✓', cls: 'text-emerald-500' }
+        if (status === 'partial') return { mark: '~', cls: 'text-amber-400' }
+        if (status === 'broken') return { mark: '✕', cls: 'text-red-400' }
+        return { mark: '?', cls: 'text-zinc-600' }
+    }
+
+    return (
+        <ToolShell
+            slug="url-compatibility-checker"
+            eyebrow="Diagnostic"
+            title="URL Compatibility Checker"
+            intro="Paste any URL and see exactly which platforms render it as a clickable link, which strip it, and why. Built for the moment a slack:// or obsidian:// link silently fails inside someone else’s tool."
+        >
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
+            />
+
+            {/* Interactive checker */}
+            <section className="py-10">
+                <CheckerClient />
+            </section>
+
+            {/* Why custom scheme URLs break */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Why custom scheme URLs break
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    Custom URL schemes like <code className="font-mono text-sm text-zinc-300">slack://</code>, <code className="font-mono text-sm text-zinc-300">obsidian://</code>, and <code className="font-mono text-sm text-zinc-300">zoommtg://</code> only become clickable when an OS-level handler is registered for them. The browser is fine handing these off to the OS &mdash; the problem is upstream: most content platforms (Notion, Confluence, Gmail, GitHub, Linear) sanitize URLs before rendering, and their allowlists rarely extend past <code className="font-mono text-sm text-zinc-300">https</code>, <code className="font-mono text-sm text-zinc-300">http</code>, <code className="font-mono text-sm text-zinc-300">mailto</code>, and <code className="font-mono text-sm text-zinc-300">tel</code>.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    The result: a <code className="font-mono text-sm text-zinc-300">slack://channel</code> link pasted into a Notion page silently becomes plain text. The link target is intact, but the platform refuses to render it as an anchor. The fix is to wrap the custom scheme inside an <code className="font-mono text-sm text-zinc-300">https://</code> URL that handles the redirect client-side &mdash; which is exactly what <a href="/" className="text-emerald-500 hover:text-emerald-400">Shortlink</a> does.
+                </p>
+            </section>
+
+            {/* Static reference matrix */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Compatibility matrix
+                </h2>
+                <p className="text-zinc-500 text-sm mb-6 max-w-[60ch]">
+                    Reference table covering common schemes across major content platforms. <span className="text-emerald-500">✓</span> = renders as clickable link. <span className="text-red-400">✕</span> = stripped or rendered as plain text. <span className="text-amber-400">~</span> = partial / depends on client.
+                </p>
+                <div className="overflow-x-auto border border-zinc-800">
+                    <table className="w-full font-mono text-xs">
+                        <thead>
+                            <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
+                                <th className="text-left p-3 border-b border-zinc-800">Scheme</th>
+                                {PLATFORMS.map(p => (
+                                    <th key={p.id} className="text-center p-3 border-b border-zinc-800 border-l border-zinc-800/60">
+                                        {p.name}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {matrix.map(row => (
+                                <tr key={row.scheme} className="border-b border-zinc-900">
+                                    <td className="p-3 text-emerald-500">{row.display}</td>
+                                    {row.cells.map(c => {
+                                        const s = symbol(c.status)
+                                        return (
+                                            <td key={c.platform.id} className="text-center p-3 border-l border-zinc-800/60">
+                                                <span className={`text-base font-bold ${s.cls}`} title={c.notes}>
+                                                    {s.mark}
+                                                </span>
+                                            </td>
+                                        )
+                                    })}
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            {/* Per-platform breakdown */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6">
+                    Platform-by-platform breakdown
+                </h2>
+                <div className="space-y-3">
+                    {PLATFORMS.map(p => (
+                        <details key={p.id} className="group border border-zinc-800">
+                            <summary className="flex items-center justify-between p-4 cursor-pointer">
+                                <span className="text-white text-sm font-medium pr-4">{p.name}</span>
+                                <span className="font-mono text-zinc-600 text-xs group-open:rotate-45 transition-transform shrink-0">+</span>
+                            </summary>
+                            <div className="px-4 pb-4 space-y-2">
+                                <p className="text-zinc-400 text-xs leading-relaxed">{p.notes}</p>
+                                <div className="font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                                    Allows: <span className="text-emerald-500">{p.allows.join(', ')}</span>
+                                </div>
+                                <div className="font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                                    Blocks: <span className="text-red-400">{p.blocks === '*' ? 'everything else' : p.blocks.join(', ') || 'none'}</span>
+                                </div>
+                            </div>
+                        </details>
+                    ))}
+                </div>
+            </section>
+
+            <GeoGrid heading="Where this problem hits hardest" />
+
+            <Faq items={FAQ_ITEMS} />
+        </ToolShell>
+    )
+}

--- a/app/tools/url-scheme-registry/page.js
+++ b/app/tools/url-scheme-registry/page.js
@@ -1,0 +1,159 @@
+import ToolShell from 'components/tools/tool-shell'
+import Faq from 'components/tools/faq'
+import GeoGrid from 'components/tools/geo-grid'
+import RegistryClient from 'components/tools/registry-client'
+import { URL_SCHEMES } from 'utils/data/url-schemes'
+
+export const metadata = {
+    title: 'URL Scheme Registry',
+    description: 'Searchable registry of every app deep link URL scheme — Slack, Obsidian, Zoom, Notion, Figma, VS Code and 40+ more. Free reference for developers and PMs.',
+    alternates: { canonical: '/tools/url-scheme-registry' },
+    openGraph: {
+        title: 'URL Scheme Registry — Shortlink',
+        description: 'Searchable reference for every app URL scheme.',
+        url: 'https://www.shortlink.studio/tools/url-scheme-registry',
+        images: ['/preview.png'],
+    },
+}
+
+const FAQ_ITEMS = [
+    {
+        q: 'What is a URL scheme?',
+        a: 'A URL scheme is the protocol prefix at the start of a URL, like https:// or slack://. Apps register custom schemes with the operating system so that links using their scheme open the app directly. Examples include obsidian://, zoom://, notion://, and vscode://.',
+    },
+    {
+        q: 'How do I find an app’s custom URL scheme?',
+        a: 'Most apps publish their URL scheme in their developer documentation. On macOS you can also inspect an app’s Info.plist file under CFBundleURLSchemes. On iOS the same key is in the bundle. The Shortlink registry above documents the schemes for 50+ popular apps.',
+    },
+    {
+        q: 'What is the Slack URL scheme?',
+        a: 'Slack uses the slack:// scheme. Common formats include slack://channel?team=T0001&id=C0001 to open a channel and slack://user?team=T0001&id=U0001 to open a DM. These links work on macOS, Windows, iOS, and Android Slack clients.',
+    },
+    {
+        q: 'What is the zoom:// protocol?',
+        a: 'Zoom registers two schemes: zoommtg:// (used by the legacy desktop client) and zoomus:// (used by newer clients). The most common format is zoommtg://zoom.us/join?confno=123456789 to join a meeting by ID.',
+    },
+    {
+        q: 'How do I open VS Code from a browser link?',
+        a: 'Use the vscode:// scheme. Examples: vscode://file/path/to/file.js to open a specific file, vscode://settings to open settings, or vscode://vscode.git/clone?url=https://github.com/user/repo to clone a repository.',
+    },
+    {
+        q: 'Why don’t custom URL schemes work in browsers?',
+        a: 'Browsers can launch custom schemes via the OS handler, but most websites strip non-HTTP(S) URLs from rendered content for security. Pasting slack:// or obsidian:// into Notion, Confluence, or an email body usually results in plain text, not a clickable link. Wrapping the scheme in an HTTPS URL with Shortlink solves this.',
+    },
+]
+
+export default function UrlSchemeRegistryPage() {
+    const wrappable = URL_SCHEMES.filter(s => s.wraps).length
+
+    const webAppLd = {
+        '@context': 'https://schema.org',
+        '@type': 'WebApplication',
+        name: 'URL Scheme Registry',
+        url: 'https://www.shortlink.studio/tools/url-scheme-registry/',
+        applicationCategory: 'UtilitiesApplication',
+        operatingSystem: 'Any',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        description: metadata.description,
+        featureList: [
+            'Searchable reference for 50+ app URL schemes',
+            'Per-app example deep link URL',
+            'Platform support details (macOS, Windows, Linux, iOS, Android)',
+            'Indicates which schemes Shortlink can wrap into HTTPS',
+        ],
+    }
+
+    return (
+        <ToolShell
+            slug="url-scheme-registry"
+            eyebrow="Reference"
+            title="URL Scheme Registry"
+            intro={`A searchable reference for every app URL scheme — ${URL_SCHEMES.length} entries covering productivity, dev, and communication tools. Use this to look up the exact deep-link format an app expects, or to confirm whether a scheme exists at all.`}
+        >
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
+            />
+
+            {/* Searchable client table */}
+            <section className="py-10">
+                <RegistryClient schemes={URL_SCHEMES} />
+            </section>
+
+            {/* Static fallback table — duplicates the data for crawlers regardless of JS */}
+            <section className="border-t border-zinc-800 py-10" aria-hidden="false">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Full URL scheme reference
+                </h2>
+                <p className="text-zinc-500 text-sm mb-6 max-w-[60ch]">
+                    The complete list, also indexable without JavaScript. {wrappable} of {URL_SCHEMES.length} schemes can be wrapped into a universal HTTPS link via Shortlink.
+                </p>
+                <div className="overflow-x-auto border border-zinc-800">
+                    <table className="w-full font-mono text-xs">
+                        <thead>
+                            <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
+                                <th className="text-left p-3 border-b border-zinc-800">App</th>
+                                <th className="text-left p-3 border-b border-zinc-800">Scheme</th>
+                                <th className="text-left p-3 border-b border-zinc-800 hidden md:table-cell">Example</th>
+                                <th className="text-left p-3 border-b border-zinc-800 hidden lg:table-cell">Platforms</th>
+                                <th className="text-left p-3 border-b border-zinc-800">Wraps?</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {URL_SCHEMES.map(s => (
+                                <tr key={'static-' + s.app + s.scheme} className="border-b border-zinc-900">
+                                    <td className="p-3 text-white">{s.app}</td>
+                                    <td className="p-3 text-emerald-500">{s.scheme}</td>
+                                    <td className="p-3 text-zinc-500 hidden md:table-cell truncate max-w-[280px]">{s.example}</td>
+                                    <td className="p-3 text-zinc-500 hidden lg:table-cell">{s.platforms.join(', ')}</td>
+                                    <td className="p-3">{s.wraps ? <span className="text-emerald-500">Yes</span> : <span className="text-zinc-600">No</span>}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            {/* Explainer sections */}
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    What is a URL scheme?
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    A URL scheme is the protocol identifier at the start of a URL &mdash; the part before the colon. Standard schemes like <code className="font-mono text-sm text-zinc-300">https</code>, <code className="font-mono text-sm text-zinc-300">http</code>, <code className="font-mono text-sm text-zinc-300">mailto</code>, and <code className="font-mono text-sm text-zinc-300">tel</code> are recognized by every browser and platform.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    Custom URL schemes like <code className="font-mono text-sm text-zinc-300">slack://</code> or <code className="font-mono text-sm text-zinc-300">obsidian://</code> are registered by individual applications. When the operating system sees one of these schemes in a clicked link, it hands the URL to the app that registered it. This is how apps implement deep links into specific channels, vaults, files, or meetings.
+                </p>
+            </section>
+
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    How apps register custom URL schemes
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    On macOS and iOS, apps declare their schemes in <code className="font-mono text-sm text-zinc-300">Info.plist</code> under <code className="font-mono text-sm text-zinc-300">CFBundleURLTypes</code>. On Windows the registration lives in the Registry under <code className="font-mono text-sm text-zinc-300">HKEY_CLASSES_ROOT</code>. On Android, apps declare intent filters in their manifest with a custom scheme.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    Once registered, clicking a link with that scheme prompts the OS to launch the app and pass it the full URL. The app then parses the URL’s host, path, and query parameters to decide what to open.
+                </p>
+            </section>
+
+            <section className="border-t border-zinc-800 py-10">
+                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
+                    Browser vs OS: who handles custom schemes?
+                </h2>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch] mb-4">
+                    The browser is the messenger; the OS is the dispatcher. When you click a custom-scheme link, the browser doesn’t try to fetch it &mdash; it asks the OS which app handles that scheme. The OS launches the app and passes it the URL.
+                </p>
+                <p className="text-zinc-400 leading-relaxed max-w-[60ch]">
+                    Problems arise when content platforms (Notion, Confluence, Gmail, GitHub) sanitize or strip non-HTTPS links before rendering. Even though the browser would correctly hand off the URL to the OS, these platforms never let the link reach the browser as a clickable element. Wrapping the scheme in an HTTPS link via <a href="/" className="text-emerald-500 hover:text-emerald-400">Shortlink</a> works around this.
+                </p>
+            </section>
+
+            <GeoGrid heading="Where these schemes get used" />
+
+            <Faq items={FAQ_ITEMS} />
+        </ToolShell>
+    )
+}

--- a/components/header.js
+++ b/components/header.js
@@ -10,6 +10,7 @@ const Header = () =>
                 <span className="text-xl font-bold text-white">Shortlink</span>
             </a>
             <nav className="flex items-center gap-6">
+                <a href="/tools/" className="text-sm text-zinc-500 hover:text-emerald-500 transition-colors">Tools</a>
                 <a href="/about" className="text-sm text-zinc-500 hover:text-emerald-500 transition-colors">About</a>
                 <a href="/contact" className="text-sm text-zinc-500 hover:text-emerald-500 transition-colors">Contact</a>
             </nav>

--- a/components/tools/builder-client.js
+++ b/components/tools/builder-client.js
@@ -1,0 +1,190 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { shouldCompress } from 'utils/codec'
+import CopyButton from 'components/tools/copy-button'
+
+const APPS = [
+    {
+        id: 'slack',
+        name: 'Slack',
+        scheme: 'slack://',
+        fields: [
+            { id: 'team', label: 'Team ID', placeholder: 'T0001', required: true, hint: 'Find this in your Slack URL: app.slack.com/client/T0001/...' },
+            { id: 'channel', label: 'Channel ID', placeholder: 'C0001', required: true, hint: 'In Slack, right-click a channel → Copy link.' },
+            { id: 'ts', label: 'Message timestamp', placeholder: '1700000000.001234', required: false, hint: 'Optional. Targets a specific message.' },
+        ],
+        build: (v) => {
+            const base = `slack://channel?team=${encodeURIComponent(v.team)}&id=${encodeURIComponent(v.channel)}`
+            return v.ts ? `${base}&message=${encodeURIComponent(v.ts)}` : base
+        },
+    },
+    {
+        id: 'obsidian',
+        name: 'Obsidian',
+        scheme: 'obsidian://',
+        fields: [
+            { id: 'vault', label: 'Vault name', placeholder: 'MyVault', required: true, hint: 'The display name of your vault.' },
+            { id: 'file', label: 'Note path', placeholder: 'Folder/Note', required: true, hint: 'Path inside the vault, without the .md extension.' },
+            { id: 'heading', label: 'Heading anchor', placeholder: 'Section title', required: false, hint: 'Optional. Jumps to a specific heading.' },
+        ],
+        build: (v) => {
+            const base = `obsidian://open?vault=${encodeURIComponent(v.vault)}&file=${encodeURIComponent(v.file)}`
+            return v.heading ? `${base}#${encodeURIComponent(v.heading)}` : base
+        },
+    },
+    {
+        id: 'zoom',
+        name: 'Zoom',
+        scheme: 'zoommtg://',
+        fields: [
+            { id: 'meeting', label: 'Meeting ID', placeholder: '123456789', required: true, hint: 'The numeric Zoom meeting ID.' },
+            { id: 'pwd', label: 'Passcode', placeholder: 'abc123', required: false, hint: 'Optional. Pre-fills the meeting passcode.' },
+        ],
+        build: (v) => {
+            const base = `zoommtg://zoom.us/join?action=join&confno=${encodeURIComponent(v.meeting)}`
+            return v.pwd ? `${base}&pwd=${encodeURIComponent(v.pwd)}` : base
+        },
+    },
+    {
+        id: 'notion',
+        name: 'Notion',
+        scheme: 'notion://',
+        fields: [
+            { id: 'page', label: 'Notion page URL or ID', placeholder: 'https://www.notion.so/Page-abc123...', required: true, hint: 'Paste the full Notion URL — the page ID is auto-extracted.' },
+        ],
+        build: (v) => {
+            const idMatch = (v.page || '').match(/([a-f0-9]{32})/i)
+            if (idMatch) return `notion://www.notion.so/${idMatch[1]}`
+            const cleaned = (v.page || '').replace(/^https?:\/\//, '')
+            return `notion://${cleaned}`
+        },
+    },
+    {
+        id: 'figma',
+        name: 'Figma',
+        scheme: 'figma://',
+        fields: [
+            { id: 'fileKey', label: 'File key', placeholder: 'abc123def456', required: true, hint: 'From the Figma URL: figma.com/file/<key>/...' },
+            { id: 'node', label: 'Node ID', placeholder: '1:23', required: false, hint: 'Optional. Targets a specific frame or layer.' },
+        ],
+        build: (v) => {
+            const base = `figma://file/${encodeURIComponent(v.fileKey)}`
+            return v.node ? `${base}?node-id=${encodeURIComponent(v.node)}` : base
+        },
+    },
+    {
+        id: 'other',
+        name: 'Other',
+        scheme: '*://',
+        fields: [
+            { id: 'scheme', label: 'Scheme', placeholder: 'myapp', required: true, hint: 'Without the trailing colon or slashes.' },
+            { id: 'path', label: 'Path / query', placeholder: 'open?id=123', required: true, hint: 'Everything after the scheme prefix.' },
+        ],
+        build: (v) => `${(v.scheme || '').replace(/[:/]+$/, '')}://${(v.path || '').replace(/^\/+/, '')}`,
+    },
+]
+
+export default function BuilderClient() {
+    const [activeId, setActiveId] = useState(APPS[0].id)
+    const [values, setValues] = useState({})
+
+    const active = APPS.find(a => a.id === activeId)
+    const valid = active.fields.every(f => !f.required || (values[f.id] || '').trim().length > 0)
+
+    const rawUrl = useMemo(() => {
+        if (!valid) return ''
+        try {
+            return active.build(values)
+        } catch {
+            return ''
+        }
+    }, [active, values, valid])
+
+    const shortlinkUrl = useMemo(() => {
+        if (!rawUrl) return ''
+        const result = shouldCompress(rawUrl, '1')
+        const path = result.useCompression ? `s/${result.compressed}` : result.legacy
+        return `https://www.shortlink.studio/${path}`
+    }, [rawUrl])
+
+    const handleField = (id, val) => setValues(v => ({ ...v, [id]: val }))
+    const handleApp = (id) => {
+        setActiveId(id)
+        setValues({})
+    }
+
+    return (
+        <div className="space-y-6">
+            {/* App tabs */}
+            <div className="flex flex-wrap gap-px bg-zinc-800 border border-zinc-800">
+                {APPS.map(a => (
+                    <button
+                        key={a.id}
+                        type="button"
+                        onClick={() => handleApp(a.id)}
+                        className={`px-4 py-3 font-mono text-xs uppercase tracking-widest transition-colors ${
+                            activeId === a.id
+                                ? 'bg-zinc-950 text-emerald-500'
+                                : 'bg-zinc-900 text-zinc-500 hover:text-zinc-300'
+                        }`}
+                    >
+                        {a.name}
+                    </button>
+                ))}
+            </div>
+
+            {/* Fields */}
+            <div className="bg-zinc-950 border border-zinc-800 p-5 sm:p-6 space-y-5">
+                {active.fields.map(f => (
+                    <div key={f.id}>
+                        <label htmlFor={`builder-${active.id}-${f.id}`} className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
+                            {f.label}{f.required && <span className="text-emerald-600 ml-1">*</span>}
+                        </label>
+                        <input
+                            id={`builder-${active.id}-${f.id}`}
+                            type="text"
+                            autoCapitalize="off"
+                            autoComplete="off"
+                            autoCorrect="off"
+                            spellCheck="false"
+                            value={values[f.id] || ''}
+                            onChange={e => handleField(f.id, e.target.value)}
+                            placeholder={f.placeholder}
+                            className="w-full bg-zinc-900 border border-zinc-700 text-white font-mono text-sm px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                        />
+                        {f.hint && (
+                            <p className="mt-1.5 text-zinc-500 text-xs leading-relaxed">{f.hint}</p>
+                        )}
+                    </div>
+                ))}
+            </div>
+
+            {/* Output */}
+            <div className="grid grid-cols-1 gap-px bg-zinc-800 border border-zinc-800">
+                <div className="bg-zinc-950 p-5 sm:p-6">
+                    <div className="flex items-center justify-between mb-3">
+                        <span className="font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                            Raw {active.scheme} URL
+                        </span>
+                        <CopyButton value={rawUrl} disabled={!rawUrl} />
+                    </div>
+                    <code className="block font-mono text-sm text-emerald-500 break-all whitespace-pre-wrap min-h-[1.5em]">
+                        {rawUrl || <span className="text-zinc-600">Fill in the required fields…</span>}
+                    </code>
+                </div>
+                <div className="bg-zinc-950 p-5 sm:p-6">
+                    <div className="flex items-center justify-between mb-3">
+                        <span className="font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                            Universal Shortlink (works everywhere)
+                        </span>
+                        <CopyButton value={shortlinkUrl} disabled={!shortlinkUrl} />
+                    </div>
+                    <code className="block font-mono text-sm text-white break-all whitespace-pre-wrap min-h-[1.5em]">
+                        {shortlinkUrl || <span className="text-zinc-600">—</span>}
+                    </code>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/components/tools/checker-client.js
+++ b/components/tools/checker-client.js
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState } from 'react'
+import { PLATFORMS, check, extractScheme } from 'utils/data/platform-rules'
+
+const STATUS_STYLES = {
+    works: { label: 'Works', cls: 'text-emerald-500' },
+    partial: { label: 'Partial', cls: 'text-amber-400' },
+    broken: { label: 'Broken', cls: 'text-red-400' },
+    unknown: { label: 'Unknown', cls: 'text-zinc-500' },
+}
+
+export default function CheckerClient() {
+    const [input, setInput] = useState('')
+    const [scheme, setScheme] = useState('')
+    const [results, setResults] = useState(null)
+
+    const handleCheck = () => {
+        const detected = extractScheme(input)
+        setScheme(detected)
+        if (!detected) {
+            setResults(null)
+            return
+        }
+        setResults(PLATFORMS.map(p => check(detected, p)))
+    }
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        handleCheck()
+    }
+
+    return (
+        <div className="space-y-6">
+            <form onSubmit={handleSubmit}>
+                <label htmlFor="checker-input" className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
+                    Paste any URL
+                </label>
+                <div className="flex gap-px bg-zinc-800">
+                    <input
+                        id="checker-input"
+                        type="text"
+                        value={input}
+                        onChange={e => setInput(e.target.value)}
+                        autoCapitalize="off"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        spellCheck="false"
+                        placeholder="slack://channel?team=T0001&id=C0001"
+                        className="flex-1 bg-zinc-900 border border-zinc-700 text-white font-mono text-base px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                    />
+                    <button
+                        type="submit"
+                        className="bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-white font-display font-bold py-3 px-6 text-xs tracking-wider uppercase transition-all whitespace-nowrap"
+                    >
+                        Check
+                    </button>
+                </div>
+                {scheme && (
+                    <div className="mt-3 font-mono text-xs text-zinc-500">
+                        Detected scheme: <span className="text-emerald-500">{scheme}://</span>
+                    </div>
+                )}
+                {input && !scheme && results === null && (
+                    <div className="mt-3 font-mono text-xs text-amber-400">
+                        Could not detect a URL scheme. Try a URL like <code>slack://...</code>.
+                    </div>
+                )}
+            </form>
+
+            {results && (
+                <div>
+                    <h3 className="font-display text-lg font-bold text-white mb-4">
+                        Compatibility for <code className="text-emerald-500 font-mono text-base">{scheme}://</code>
+                    </h3>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-zinc-800">
+                        {results.map(r => {
+                            const style = STATUS_STYLES[r.status]
+                            return (
+                                <div key={r.platform.id} className="bg-zinc-950 p-5">
+                                    <div className="flex items-center justify-between mb-2">
+                                        <span className="text-white font-bold text-sm">{r.platform.name}</span>
+                                        <span className={`font-mono text-[10px] uppercase tracking-widest ${style.cls}`}>
+                                            {style.label}
+                                        </span>
+                                    </div>
+                                    <p className="text-zinc-500 text-xs leading-relaxed">{r.notes}</p>
+                                </div>
+                            )
+                        })}
+                    </div>
+                    {results.some(r => r.status === 'broken') && (
+                        <div className="mt-6 bg-zinc-950 border border-emerald-900/40 p-5">
+                            <p className="text-zinc-300 text-sm">
+                                Some platforms above strip this scheme.{' '}
+                                <a href="/" className="text-emerald-500 hover:text-emerald-400 font-medium">
+                                    Wrap it in a Shortlink →
+                                </a>
+                            </p>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/components/tools/copy-button.js
+++ b/components/tools/copy-button.js
@@ -1,0 +1,40 @@
+'use client'
+
+import { useState } from 'react'
+
+// Reusable copy-to-clipboard button. Defaults to compact size for use inside
+// output tiles; pass size="lg" for the primary CTA style.
+
+export default function CopyButton({ value, label = 'Copy', size = 'sm', className = '', disabled = false }) {
+    const [text, setText] = useState(label)
+
+    const handleClick = async () => {
+        if (!value) return
+        try {
+            await navigator.clipboard.writeText(value)
+            setText('Copied')
+            setTimeout(() => setText(label), 2000)
+        } catch {
+            setText('Failed')
+            setTimeout(() => setText(label), 2000)
+        }
+    }
+
+    const base = 'bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-white font-display font-bold tracking-wider uppercase transition-all disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-emerald-600'
+    const sizes = {
+        sm: 'py-2 px-3 text-[10px]',
+        md: 'py-3 px-5 text-xs',
+        lg: 'py-4 px-6 text-sm',
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={handleClick}
+            disabled={disabled || !value}
+            className={`${base} ${sizes[size] || sizes.sm} ${className}`}
+        >
+            {text}
+        </button>
+    )
+}

--- a/components/tools/faq.js
+++ b/components/tools/faq.js
@@ -1,0 +1,41 @@
+// Server component: renders FAQ accordion + emits FAQPage JSON-LD.
+// Q&A bodies appear in the DOM (Google requires this for rich results).
+
+export default function Faq({ items, heading = 'FAQ' }) {
+    if (!items || items.length === 0) return null
+
+    const jsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: items.map(({ q, a }) => ({
+            '@type': 'Question',
+            name: q,
+            acceptedAnswer: { '@type': 'Answer', text: a },
+        })),
+    }
+
+    return (
+        <section className="border-t border-zinc-800 py-10">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+            />
+            <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6">
+                {heading}
+            </h2>
+            <div className="space-y-3 max-w-2xl">
+                {items.map((faq, i) => (
+                    <details key={i} className="group border border-zinc-800">
+                        <summary className="flex items-center justify-between p-4 cursor-pointer">
+                            <span className="text-white text-sm font-medium pr-4">{faq.q}</span>
+                            <span className="font-mono text-zinc-600 text-xs group-open:rotate-45 transition-transform shrink-0">+</span>
+                        </summary>
+                        <div className="px-4 pb-4">
+                            <p className="text-zinc-400 text-xs leading-relaxed whitespace-pre-line">{faq.a}</p>
+                        </div>
+                    </details>
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/components/tools/geo-grid.js
+++ b/components/tools/geo-grid.js
@@ -1,0 +1,43 @@
+import { GEO_VARIANTS } from 'utils/data/geo-variants'
+import GeoHighlight from 'components/tools/geo-highlight'
+
+// Server-renders ALL regional variants statically. The GeoHighlight client
+// island reads timezone and adds a "popular near you" badge to the matching
+// card — it never hides anything, so every variant is indexed by Google.
+
+export default function GeoGrid({ heading = 'How teams use this around the world' }) {
+    return (
+        <section id="geo-content" className="border-t border-zinc-800 py-10">
+            <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6">
+                {heading}
+            </h2>
+            <GeoHighlight />
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-px bg-zinc-800">
+                {GEO_VARIANTS.map(v => (
+                    <article
+                        key={v.id}
+                        data-geo-variant={v.id}
+                        className="bg-zinc-950 p-5 sm:p-6 relative"
+                    >
+                        <header className="flex items-center justify-between mb-3">
+                            <span className="font-mono text-[10px] uppercase tracking-widest text-emerald-600">
+                                {v.region}
+                            </span>
+                            <span
+                                data-geo-badge
+                                className="hidden font-mono text-[9px] uppercase tracking-widest text-zinc-950 bg-emerald-500 px-1.5 py-0.5"
+                            >
+                                Popular near you
+                            </span>
+                        </header>
+                        <p className="text-zinc-400 text-xs leading-relaxed mb-3">{v.intro}</p>
+                        <p className="text-zinc-500 text-xs leading-relaxed border-t border-zinc-800 pt-3">
+                            <span className="text-zinc-300 font-medium">Use case: </span>
+                            {v.useCase}
+                        </p>
+                    </article>
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/components/tools/geo-highlight.js
+++ b/components/tools/geo-highlight.js
@@ -1,0 +1,29 @@
+'use client'
+
+import { useEffect } from 'react'
+import { TZ_TO_VARIANT } from 'utils/data/geo-variants'
+
+// Client island: reads timezone, finds the matching geo card,
+// and reveals the "popular near you" badge on it. Pure progressive
+// enhancement — if JS fails, all variants still render statically.
+
+export default function GeoHighlight() {
+    useEffect(() => {
+        try {
+            const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+            const variantId = TZ_TO_VARIANT[tz] || 'default'
+            const card = document.querySelector(`[data-geo-variant="${variantId}"]`)
+            if (!card) return
+            const badge = card.querySelector('[data-geo-badge]')
+            if (badge) {
+                badge.classList.remove('hidden')
+                badge.classList.add('inline-block')
+            }
+            card.classList.add('ring-1', 'ring-emerald-700/40')
+        } catch {
+            // No-op: static grid is the fallback.
+        }
+    }, [])
+
+    return null
+}

--- a/components/tools/markdown-client.js
+++ b/components/tools/markdown-client.js
@@ -1,0 +1,162 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { shouldCompress } from 'utils/codec'
+import { extractScheme } from 'utils/data/platform-rules'
+import CopyButton from 'components/tools/copy-button'
+
+function buildShortlink(url) {
+    if (!url) return ''
+    const result = shouldCompress(url, '1')
+    const path = result.useCompression ? `s/${result.compressed}` : result.legacy
+    return `https://www.shortlink.studio/${path}`
+}
+
+export default function MarkdownClient() {
+    const [url, setUrl] = useState('')
+    const [label, setLabel] = useState('')
+    const [useShortlink, setUseShortlink] = useState(false)
+
+    const detectedScheme = useMemo(() => extractScheme(url), [url])
+    const isCustomScheme = detectedScheme && detectedScheme !== 'https' && detectedScheme !== 'http' && detectedScheme !== 'mailto' && detectedScheme !== 'tel'
+
+    const finalUrl = useMemo(() => {
+        if (!url) return ''
+        if (useShortlink && isCustomScheme) {
+            return buildShortlink(url) || url
+        }
+        return url
+    }, [url, useShortlink, isCustomScheme])
+
+    const finalLabel = label || finalUrl || 'link'
+
+    const formats = useMemo(() => {
+        if (!finalUrl) return []
+        return [
+            {
+                id: 'markdown',
+                name: 'Markdown / Notion',
+                value: `[${finalLabel}](${finalUrl})`,
+                hint: 'Standard CommonMark. Works in Notion, Bear, Logseq, GitHub READMEs.',
+            },
+            {
+                id: 'wikilink',
+                name: 'Obsidian wikilink',
+                value: `[[${finalUrl}|${finalLabel}]]`,
+                hint: 'Native Obsidian syntax. Note: wikilinks are designed for internal vault notes — for external URLs prefer the Markdown format above.',
+            },
+            {
+                id: 'slack',
+                name: 'Slack mrkdwn',
+                value: `<${finalUrl}|${finalLabel}>`,
+                hint: 'For Slack messages, posts, and Block Kit text fields.',
+            },
+            {
+                id: 'html',
+                name: 'HTML anchor',
+                value: `<a href="${finalUrl}">${finalLabel}</a>`,
+                hint: 'For email signatures, raw HTML emails, or any HTML-rendering surface.',
+            },
+            {
+                id: 'rst',
+                name: 'reStructuredText',
+                value: `\`${finalLabel} <${finalUrl}>\`_`,
+                hint: 'For Sphinx docs and Python project READMEs.',
+            },
+            {
+                id: 'plain',
+                name: 'Plain URL',
+                value: finalUrl,
+                hint: 'For surfaces that auto-link bare URLs (Slack, Discord, Twitter).',
+            },
+        ]
+    }, [finalUrl, finalLabel])
+
+    return (
+        <div className="space-y-6">
+            {/* Inputs */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-zinc-800 border border-zinc-800">
+                <div className="bg-zinc-950 p-5">
+                    <label htmlFor="md-url" className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
+                        URL
+                    </label>
+                    <input
+                        id="md-url"
+                        type="text"
+                        autoCapitalize="off"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        spellCheck="false"
+                        value={url}
+                        onChange={e => setUrl(e.target.value)}
+                        placeholder="https://example.com or slack://channel?team=..."
+                        className="w-full bg-zinc-900 border border-zinc-700 text-white font-mono text-sm px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                    />
+                </div>
+                <div className="bg-zinc-950 p-5">
+                    <label htmlFor="md-label" className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
+                        Label (visible text)
+                    </label>
+                    <input
+                        id="md-label"
+                        type="text"
+                        value={label}
+                        onChange={e => setLabel(e.target.value)}
+                        placeholder="Click here"
+                        className="w-full bg-zinc-900 border border-zinc-700 text-white font-mono text-sm px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                    />
+                </div>
+            </div>
+
+            {/* Custom-scheme toggle */}
+            {isCustomScheme && (
+                <div className="bg-zinc-950 border border-emerald-900/40 p-4 sm:p-5 flex items-center justify-between gap-4">
+                    <div>
+                        <div className="text-white font-bold text-sm mb-1">
+                            Detected custom scheme: <code className="text-emerald-500 font-mono">{detectedScheme}://</code>
+                        </div>
+                        <p className="text-zinc-500 text-xs leading-relaxed max-w-[55ch]">
+                            Most platforms strip non-HTTPS schemes. Toggle on to wrap this URL in a Shortlink so it renders as a clickable link in Notion, Gmail, Confluence, GitHub, etc.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => setUseShortlink(!useShortlink)}
+                        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-sm transition-colors focus:outline-none ${
+                            useShortlink ? 'bg-emerald-600' : 'bg-zinc-700'
+                        }`}
+                        role="switch"
+                        aria-checked={useShortlink}
+                    >
+                        <span className={`inline-block h-3.5 w-3.5 transform rounded-sm bg-white transition-transform ${
+                            useShortlink ? 'translate-x-[18px]' : 'translate-x-[3px]'
+                        }`} />
+                    </button>
+                </div>
+            )}
+
+            {/* Output tiles */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-zinc-800">
+                {formats.length === 0 && (
+                    <div className="bg-zinc-950 p-8 text-center text-zinc-500 sm:col-span-2">
+                        Enter a URL above to see formatted link snippets.
+                    </div>
+                )}
+                {formats.map(f => (
+                    <div key={f.id} className="bg-zinc-950 p-5">
+                        <div className="flex items-center justify-between mb-3">
+                            <span className="font-mono text-[10px] uppercase tracking-widest text-zinc-400">
+                                {f.name}
+                            </span>
+                            <CopyButton value={f.value} />
+                        </div>
+                        <code className="block font-mono text-xs text-emerald-500 break-all whitespace-pre-wrap mb-2">
+                            {f.value}
+                        </code>
+                        <p className="text-zinc-500 text-[11px] leading-relaxed">{f.hint}</p>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/components/tools/registry-client.js
+++ b/components/tools/registry-client.js
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+
+// Client island for the URL Scheme Registry. Renders the same table the
+// server already rendered, but with a search filter on top. The page server
+// component still renders the full static table for crawlers — this component
+// progressively replaces it once JS hydrates.
+
+export default function RegistryClient({ schemes }) {
+    const [query, setQuery] = useState('')
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase()
+        if (!q) return schemes
+        return schemes.filter(s =>
+            s.app.toLowerCase().includes(q) ||
+            s.scheme.toLowerCase().includes(q)
+        )
+    }, [query, schemes])
+
+    return (
+        <div className="space-y-5">
+            <div>
+                <label className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
+                    Search the registry
+                </label>
+                <input
+                    type="search"
+                    value={query}
+                    onChange={e => setQuery(e.target.value)}
+                    placeholder="slack, obsidian, vscode, ..."
+                    className="w-full bg-zinc-900 border border-zinc-700 text-white font-mono text-base px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                />
+                <div className="mt-2 font-mono text-[10px] uppercase tracking-widest text-zinc-600">
+                    {filtered.length} of {schemes.length} schemes
+                </div>
+            </div>
+
+            <div className="overflow-x-auto border border-zinc-800">
+                <table className="w-full font-mono text-xs">
+                    <thead>
+                        <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
+                            <th className="text-left p-3 border-b border-zinc-800">App</th>
+                            <th className="text-left p-3 border-b border-zinc-800">Scheme</th>
+                            <th className="text-left p-3 border-b border-zinc-800 hidden md:table-cell">Example</th>
+                            <th className="text-left p-3 border-b border-zinc-800 hidden lg:table-cell">Platforms</th>
+                            <th className="text-left p-3 border-b border-zinc-800">Wraps?</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {filtered.map(s => (
+                            <tr key={s.scheme + s.app} className="border-b border-zinc-900 hover:bg-zinc-900/50">
+                                <td className="p-3 text-white">{s.app}</td>
+                                <td className="p-3 text-emerald-500">{s.scheme}</td>
+                                <td className="p-3 text-zinc-500 hidden md:table-cell truncate max-w-[280px]">{s.example}</td>
+                                <td className="p-3 text-zinc-500 hidden lg:table-cell">{s.platforms.join(', ')}</td>
+                                <td className="p-3">
+                                    {s.wraps ? (
+                                        <span className="text-emerald-500">Yes</span>
+                                    ) : (
+                                        <span className="text-zinc-600">No</span>
+                                    )}
+                                </td>
+                            </tr>
+                        ))}
+                        {filtered.length === 0 && (
+                            <tr>
+                                <td colSpan={5} className="p-6 text-center text-zinc-500">
+                                    No schemes match &ldquo;{query}&rdquo;.
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    )
+}

--- a/components/tools/tool-shell.js
+++ b/components/tools/tool-shell.js
@@ -1,0 +1,96 @@
+import Header from 'components/header'
+import Footer from 'components/footer'
+
+// Server component: renders the standard tool page chrome (header, breadcrumb,
+// hero, related-tools footer, site footer). Each tool's page.js wraps its
+// content in <ToolShell ...>.
+
+const ALL_TOOLS = [
+    { slug: 'url-compatibility-checker', name: 'URL Compatibility Checker', tagline: 'See which platforms render any URL' },
+    { slug: 'deep-link-builder', name: 'Deep Link Builder', tagline: 'Generate slack://, obsidian://, zoom://, notion://, figma:// links' },
+    { slug: 'markdown-link-generator', name: 'Markdown Link Generator', tagline: 'Format links for Notion, Obsidian, Slack, HTML' },
+    { slug: 'url-scheme-registry', name: 'URL Scheme Registry', tagline: 'Reference of every app deep-link protocol' },
+]
+
+export default function ToolShell({ slug, eyebrow, title, intro, children }) {
+    const others = ALL_TOOLS.filter(t => t.slug !== slug)
+
+    return (
+        <main className="min-h-[100dvh] flex flex-col">
+            <Header />
+
+            <div className="flex-1 max-w-5xl mx-auto w-full px-5">
+                {/* Breadcrumb */}
+                <nav aria-label="Breadcrumb" className="pt-8 sm:pt-10">
+                    <ol className="flex items-center gap-2 font-mono text-[10px] uppercase tracking-widest text-zinc-500">
+                        <li><a href="/" className="hover:text-emerald-500 transition-colors">Home</a></li>
+                        <li className="text-zinc-700">/</li>
+                        <li><a href="/tools/" className="hover:text-emerald-500 transition-colors">Tools</a></li>
+                        <li className="text-zinc-700">/</li>
+                        <li className="text-zinc-300">{title}</li>
+                    </ol>
+                </nav>
+
+                {/* Hero */}
+                <header className="pt-6 pb-10 border-b border-zinc-800">
+                    {eyebrow && (
+                        <span className="font-mono text-[10px] uppercase tracking-widest text-emerald-600 border border-emerald-800 px-2 py-0.5">
+                            {eyebrow}
+                        </span>
+                    )}
+                    <h1 className="font-display text-4xl sm:text-5xl md:text-6xl tracking-tighter leading-[0.95] font-bold text-white mt-4">
+                        {title}
+                    </h1>
+                    {intro && (
+                        <p className="text-zinc-400 leading-relaxed max-w-[60ch] mt-5">
+                            {intro}
+                        </p>
+                    )}
+                </header>
+
+                {children}
+
+                {/* Related tools */}
+                <section className="border-t border-zinc-800 py-10 mt-12">
+                    <span className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-5">
+                        Related tools
+                    </span>
+                    <div className="grid grid-cols-1 sm:grid-cols-3 gap-px bg-zinc-800">
+                        {others.map(t => (
+                            <a
+                                key={t.slug}
+                                href={`/tools/${t.slug}/`}
+                                className="bg-zinc-950 p-5 hover:bg-zinc-900 transition-colors block"
+                            >
+                                <div className="text-white font-bold text-sm mb-1">{t.name}</div>
+                                <p className="text-zinc-500 text-xs leading-relaxed">{t.tagline}</p>
+                            </a>
+                        ))}
+                    </div>
+                </section>
+
+                {/* Convert CTA */}
+                <section className="border-t border-zinc-800 py-10">
+                    <div className="bg-zinc-950 border border-emerald-900/40 p-6 sm:p-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                        <div>
+                            <div className="text-white font-bold text-base mb-1">Need to wrap a custom scheme URL?</div>
+                            <p className="text-zinc-500 text-xs leading-relaxed max-w-[50ch]">
+                                Use the main Shortlink converter to turn any slack://, obsidian://, zoom:// or notion:// URL into a universal HTTPS link.
+                            </p>
+                        </div>
+                        <a
+                            href="/"
+                            className="bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-white font-display font-bold py-3 px-6 text-sm tracking-wider uppercase transition-all whitespace-nowrap text-center"
+                        >
+                            Convert →
+                        </a>
+                    </div>
+                </section>
+            </div>
+
+            <Footer />
+        </main>
+    )
+}
+
+export { ALL_TOOLS }

--- a/utils/data/geo-variants.js
+++ b/utils/data/geo-variants.js
@@ -1,0 +1,79 @@
+// Regional content variants. All variants are server-rendered as a single
+// static grid (good for SEO — every variant is indexable). A small client
+// component reads Intl timezone and adds a "popular near you" badge to the
+// matching variant; nothing is hidden.
+
+export const GEO_VARIANTS = [
+    {
+        id: 'us-east',
+        region: 'US East Coast',
+        timezones: ['America/New_York', 'America/Toronto', 'America/Detroit', 'America/Montreal'],
+        intro: 'Teams across the US East Coast lean heavily on Notion as a central wiki, with Slack as the comms layer. Custom scheme URLs are most often shared inside Notion docs, where they fail silently.',
+        useCase: 'Wrap your slack:// channel deep links into HTTPS so they survive being pasted into Notion runbooks and onboarding pages.',
+    },
+    {
+        id: 'us-west',
+        region: 'US West Coast',
+        timezones: ['America/Los_Angeles', 'America/Vancouver', 'America/Denver', 'America/Phoenix'],
+        intro: 'West Coast product and design teams rely on Figma and Linear daily. Both platforms understand their own deep-link schemes but block competing ones.',
+        useCase: 'Convert figma:// prototype links into universal URLs you can drop into Linear specs without breaking the click target.',
+    },
+    {
+        id: 'uk',
+        region: 'United Kingdom',
+        timezones: ['Europe/London', 'Europe/Dublin'],
+        intro: 'UK teams frequently coordinate across Microsoft Teams, Confluence, and Jira — all of which sanitize non-HTTPS URLs aggressively.',
+        useCase: 'Embed Zoom and Slack deep links inside Confluence pages and Jira tickets by wrapping the original scheme in a Shortlink.',
+    },
+    {
+        id: 'dach',
+        region: 'DACH (Germany / Austria / Switzerland)',
+        timezones: ['Europe/Berlin', 'Europe/Vienna', 'Europe/Zurich'],
+        intro: 'In German-speaking markets, Confluence and Jira dominate enterprise documentation. Both block custom schemes natively.',
+        useCase: 'Paste Shortlinks into Confluence pages to give teammates one-click access to Zoom calls or Figma prototypes from your specs.',
+    },
+    {
+        id: 'france',
+        region: 'France',
+        timezones: ['Europe/Paris', 'Europe/Brussels', 'Europe/Luxembourg'],
+        intro: 'French product teams often combine Notion with Slack and Figma. Cross-tool linking breaks the moment a custom scheme leaves its native app.',
+        useCase: 'Generate Shortlinks once and reuse them in Slack, Notion, and email — the same HTTPS link works in every context.',
+    },
+    {
+        id: 'india',
+        region: 'India',
+        timezones: ['Asia/Kolkata', 'Asia/Calcutta'],
+        intro: 'Engineering teams across India frequently ship across time zones, leaning on async tools like Slack, Notion, and GitHub for handoffs.',
+        useCase: 'Wrap GitHub Desktop and VS Code deep links into Shortlinks so engineers on the next shift can open them directly from a Notion handoff doc.',
+    },
+    {
+        id: 'japan',
+        region: 'Japan',
+        timezones: ['Asia/Tokyo'],
+        intro: 'Tokyo-based teams often pair Slack with Figma and Notion. Sharing prototype links across these tools is common, and equally commonly broken.',
+        useCase: 'Build figma:// and slack:// deep links once with the Shortlink builder, then reuse them across every internal document.',
+    },
+    {
+        id: 'australia',
+        region: 'Australia / New Zealand',
+        timezones: ['Australia/Sydney', 'Australia/Melbourne', 'Australia/Brisbane', 'Australia/Perth', 'Pacific/Auckland'],
+        intro: 'APAC teams running Atlassian stacks (Jira + Confluence) hit the custom-scheme block almost daily.',
+        useCase: 'Convert custom scheme URLs into universal HTTPS links once, paste them anywhere, and stop manually re-explaining how to open the app.',
+    },
+    {
+        id: 'default',
+        region: 'Worldwide',
+        timezones: [],
+        intro: 'Distributed and remote teams across every region run into the same problem: deep links that work in one app break the moment they leave it.',
+        useCase: 'Use Shortlink to wrap any custom scheme URL into an HTTPS link that works in every tool your team uses.',
+    },
+]
+
+// Build a fast lookup: timezone -> variant id
+export const TZ_TO_VARIANT = (() => {
+    const map = {}
+    for (const v of GEO_VARIANTS) {
+        for (const tz of v.timezones) map[tz] = v.id
+    }
+    return map
+})()

--- a/utils/data/platform-rules.js
+++ b/utils/data/platform-rules.js
@@ -1,0 +1,111 @@
+// Platform compatibility rules for URL schemes.
+//
+// Each platform entry documents which schemes render as clickable links.
+//   allows:   schemes (without "://") that the platform reliably renders.
+//   blocks:   schemes the platform actively strips, blocks, or renders as plain text.
+//             "*" means the platform allows ONLY the schemes in `allows`.
+//   notes:    short user-facing explanation of why links break.
+//
+// Status returned by check(scheme):
+//   "works"   — scheme is in allows
+//   "broken"  — scheme is in blocks (or blocks is "*" and scheme not in allows)
+//   "partial" — desktop client supports it but the web/mobile surface does not
+//               (encoded as scheme appearing in `partial`)
+
+export const PLATFORMS = [
+    {
+        id: 'notion',
+        name: 'Notion',
+        allows: ['https', 'http', 'mailto', 'tel'],
+        blocks: '*',
+        partial: [],
+        notes: 'Notion strips non-HTTPS schemes when pasted into pages. Custom scheme URLs render as plain text.',
+    },
+    {
+        id: 'obsidian',
+        name: 'Obsidian',
+        allows: ['https', 'http', 'mailto', 'obsidian'],
+        blocks: ['slack', 'zoommtg', 'figma', 'notion'],
+        partial: [],
+        notes: 'Obsidian renders https:// and obsidian:// links natively but blocks most third-party schemes for security.',
+    },
+    {
+        id: 'slack',
+        name: 'Slack',
+        allows: ['https', 'http', 'mailto', 'tel', 'slack'],
+        blocks: ['obsidian', 'notion', 'figma', 'zoommtg'],
+        partial: [],
+        notes: 'Slack auto-links https:// and its own slack:// scheme, but other custom schemes render as plain text.',
+    },
+    {
+        id: 'gmail',
+        name: 'Gmail',
+        allows: ['https', 'http', 'mailto', 'tel'],
+        blocks: '*',
+        partial: [],
+        notes: 'Gmail web only renders standard HTTP(S), mailto, and tel links. All custom schemes render as plain text.',
+    },
+    {
+        id: 'msteams',
+        name: 'MS Teams',
+        allows: ['https', 'http', 'mailto', 'tel', 'msteams'],
+        blocks: ['slack', 'obsidian', 'zoommtg', 'figma', 'notion'],
+        partial: [],
+        notes: 'Teams supports msteams:// deep links but blocks competing custom schemes.',
+    },
+    {
+        id: 'linear',
+        name: 'Linear',
+        allows: ['https', 'http', 'mailto', 'linear'],
+        blocks: '*',
+        partial: [],
+        notes: 'Linear allows HTTPS and its own linear:// scheme. Other custom schemes render as plain text in issue descriptions.',
+    },
+    {
+        id: 'confluence',
+        name: 'Confluence',
+        allows: ['https', 'http', 'mailto'],
+        blocks: '*',
+        partial: [],
+        notes: 'Confluence sanitizes URLs and rejects custom schemes entirely. Wrap them in HTTPS first.',
+    },
+    {
+        id: 'github',
+        name: 'GitHub',
+        allows: ['https', 'http', 'mailto'],
+        blocks: '*',
+        partial: [],
+        notes: 'GitHub Markdown only auto-links HTTPS, HTTP, and mailto. Custom schemes are stripped from issue/PR/README rendering.',
+    },
+    {
+        id: 'markdown',
+        name: 'Markdown (generic)',
+        allows: ['https', 'http', 'mailto', 'ftp'],
+        blocks: [],
+        partial: [],
+        notes: 'CommonMark spec only auto-links HTTPS/HTTP/mailto/ftp. Custom schemes work in [label](url) syntax IF the renderer permits them.',
+    },
+]
+
+// Returns: { status: 'works' | 'broken' | 'partial' | 'unknown', platform, notes }
+export function check(scheme, platform) {
+    const lower = (scheme || '').toLowerCase().replace(/:.*$/, '')
+    if (!lower) return { status: 'unknown', platform, notes: 'No scheme detected.' }
+
+    if (platform.allows.includes(lower)) {
+        return { status: 'works', platform, notes: platform.notes }
+    }
+    if (Array.isArray(platform.partial) && platform.partial.includes(lower)) {
+        return { status: 'partial', platform, notes: platform.notes }
+    }
+    if (platform.blocks === '*' || (Array.isArray(platform.blocks) && platform.blocks.includes(lower))) {
+        return { status: 'broken', platform, notes: platform.notes }
+    }
+    return { status: 'unknown', platform, notes: platform.notes }
+}
+
+export function extractScheme(url) {
+    if (!url) return ''
+    const match = url.trim().match(/^([a-zA-Z][a-zA-Z0-9+.\-]*):/)
+    return match ? match[1].toLowerCase() : ''
+}

--- a/utils/data/url-schemes.js
+++ b/utils/data/url-schemes.js
@@ -1,0 +1,71 @@
+// Registry of known URL schemes — primary data source for Tools 1, 4, 7.
+//
+// Each entry:
+//   app:        display name
+//   scheme:     full prefix (e.g. "slack://")
+//   example:    a representative example URL
+//   platforms:  array of supported OSes/clients
+//   docs:       optional URL to the official scheme docs
+//   wraps:      true if Shortlink can wrap it into a universal HTTPS link
+//
+// When adding entries, prefer apps with verified, documented schemes.
+
+export const URL_SCHEMES = [
+    { app: 'Slack', scheme: 'slack://', example: 'slack://channel?team=T0001&id=C0001', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: 'https://api.slack.com/reference/deep-linking', wraps: true },
+    { app: 'Obsidian', scheme: 'obsidian://', example: 'obsidian://open?vault=MyVault&file=Note', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: 'https://help.obsidian.md/Concepts/Obsidian+URI', wraps: true },
+    { app: 'Zoom', scheme: 'zoommtg://', example: 'zoommtg://zoom.us/join?confno=123456789', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: 'https://developers.zoom.us/docs/meeting-sdk/', wraps: true },
+    { app: 'Notion', scheme: 'notion://', example: 'notion://www.notion.so/page-id', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Figma', scheme: 'figma://', example: 'figma://file/abc123/FileName', platforms: ['macOS', 'Windows'], docs: null, wraps: true },
+    { app: 'Linear', scheme: 'linear://', example: 'linear://issue/ENG-123', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'VS Code', scheme: 'vscode://', example: 'vscode://file/path/to/file.js:10:5', platforms: ['macOS', 'Windows', 'Linux'], docs: 'https://code.visualstudio.com/docs/configure/command-line', wraps: true },
+    { app: 'Cursor', scheme: 'cursor://', example: 'cursor://file/path/to/file.js', platforms: ['macOS', 'Windows', 'Linux'], docs: null, wraps: true },
+    { app: 'GitHub Desktop', scheme: 'x-github-client://', example: 'x-github-client://openRepo/https://github.com/user/repo', platforms: ['macOS', 'Windows'], docs: null, wraps: true },
+    { app: 'Spotify', scheme: 'spotify://', example: 'spotify://track/6rqhFgbbKwnb9MLmUQDhG6', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Apple Music', scheme: 'music://', example: 'music://music.apple.com/album/123456', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: '1Password', scheme: 'onepassword://', example: 'onepassword://item/uuid', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Discord', scheme: 'discord://', example: 'discord://discord.com/channels/123/456', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Telegram', scheme: 'tg://', example: 'tg://resolve?domain=username', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: 'https://core.telegram.org/api/links', wraps: true },
+    { app: 'WhatsApp', scheme: 'whatsapp://', example: 'whatsapp://send?phone=15551234567', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: 'https://faq.whatsapp.com/5913398998672934', wraps: true },
+    { app: 'Signal', scheme: 'sgnl://', example: 'sgnl://signal.me/#p/+15551234567', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Microsoft Teams', scheme: 'msteams://', example: 'msteams://l/channel/19:abc/General?tenantId=...', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: 'https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/deep-links', wraps: true },
+    { app: 'Webex', scheme: 'webex://', example: 'webex://meet?meetingNumber=123456789', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Asana', scheme: 'asana://', example: 'asana://0/0/123456789', platforms: ['macOS', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Trello', scheme: 'trello://', example: 'trello://board/abc123', platforms: ['iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Jira', scheme: 'jira://', example: 'jira://issue?key=PROJ-123', platforms: ['iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Confluence', scheme: 'confluence://', example: 'confluence://page?pageId=123456', platforms: ['iOS', 'Android'], docs: null, wraps: true },
+    { app: 'ClickUp', scheme: 'clickup://', example: 'clickup://t/abc123', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Monday', scheme: 'monday://', example: 'monday://boards/123456', platforms: ['iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Airtable', scheme: 'airtable://', example: 'airtable://base/appXXX/tblYYY', platforms: ['macOS', 'Windows', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Coda', scheme: 'coda://', example: 'coda://doc/abc123', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Craft', scheme: 'craftdocs://', example: 'craftdocs://open?blockId=abc&spaceId=xyz', platforms: ['macOS', 'iOS'], docs: 'https://www.craft.do/s/H8ZZ58Bj7hgEC2', wraps: true },
+    { app: 'Drafts', scheme: 'drafts://', example: 'drafts://x-callback-url/create?text=Hello', platforms: ['macOS', 'iOS'], docs: 'https://docs.getdrafts.com/docs/automation/urlschemes', wraps: true },
+    { app: 'Fantastical', scheme: 'fantastical2://', example: 'fantastical2://parse?sentence=Lunch+tomorrow', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'OmniFocus', scheme: 'omnifocus://', example: 'omnifocus:///add?name=New+Task', platforms: ['macOS', 'iOS'], docs: 'https://inside.omnifocus.com/url-schemes', wraps: true },
+    { app: 'Things', scheme: 'things://', example: 'things:///add?title=Buy+milk', platforms: ['macOS', 'iOS'], docs: 'https://culturedcode.com/things/support/articles/2803573/', wraps: true },
+    { app: 'Bear', scheme: 'bear://', example: 'bear://x-callback-url/open-note?id=abc123', platforms: ['macOS', 'iOS'], docs: 'https://bear.app/faq/x-callback-url-scheme-documentation/', wraps: true },
+    { app: 'DEVONthink', scheme: 'x-devonthink-item://', example: 'x-devonthink-item://uuid', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Hookmark', scheme: 'hook://', example: 'hook://file/abc?p=...', platforms: ['macOS'], docs: 'https://hookproductivity.com/help/integration/using-hooks-deep-links/', wraps: true },
+    { app: 'Logseq', scheme: 'logseq://', example: 'logseq://graph/MyGraph?page=Note', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Roam Research', scheme: 'roam://', example: 'roam://#/app/graph/page/Title', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Anytype', scheme: 'anytype://', example: 'anytype://object?objectId=abc', platforms: ['macOS', 'Windows', 'Linux', 'iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Tana', scheme: 'tana://', example: 'tana://node/abc123', platforms: ['macOS', 'Windows', 'iOS'], docs: null, wraps: true },
+    { app: 'Capacities', scheme: 'capacities://', example: 'capacities://open?spaceId=abc&objectId=xyz', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Reflect', scheme: 'reflect://', example: 'reflect://note/abc', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Mem', scheme: 'mem://', example: 'mem://m/abc123', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Sublime Text', scheme: 'subl://', example: 'subl://open?url=file:///path/to/file', platforms: ['macOS', 'Windows', 'Linux'], docs: null, wraps: true },
+    { app: 'JetBrains', scheme: 'jetbrains://', example: 'jetbrains://idea/navigate/reference?project=name&path=src/Main.java', platforms: ['macOS', 'Windows', 'Linux'], docs: 'https://www.jetbrains.com/help/idea/settings-tools-web-browsers.html', wraps: true },
+    { app: 'Warp', scheme: 'warp://', example: 'warp://action/new_tab', platforms: ['macOS'], docs: null, wraps: true },
+    { app: 'iTerm', scheme: 'iterm2://', example: 'iterm2://app/start?profile=Default', platforms: ['macOS'], docs: null, wraps: true },
+    { app: 'Tower', scheme: 'gittower://', example: 'gittower://openRepo/https://github.com/user/repo', platforms: ['macOS', 'Windows'], docs: null, wraps: true },
+    { app: 'Sourcetree', scheme: 'sourcetree://', example: 'sourcetree://cloneRepo?cloneUrl=https://github.com/user/repo', platforms: ['macOS', 'Windows'], docs: null, wraps: true },
+    { app: 'YouTube Music', scheme: 'youtubemusic://', example: 'youtubemusic://watch?v=abc123', platforms: ['iOS', 'Android'], docs: null, wraps: true },
+    { app: 'Apple Mail', scheme: 'message://', example: 'message://%3Cmessage-id%40example.com%3E', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+    { app: 'Mail (mailto)', scheme: 'mailto:', example: 'mailto:hello@example.com?subject=Hi', platforms: ['Universal'], docs: 'https://datatracker.ietf.org/doc/html/rfc6068', wraps: false },
+    { app: 'Phone', scheme: 'tel:', example: 'tel:+15551234567', platforms: ['Universal'], docs: 'https://datatracker.ietf.org/doc/html/rfc3966', wraps: false },
+    { app: 'SMS', scheme: 'sms:', example: 'sms:+15551234567?body=Hi', platforms: ['Universal'], docs: null, wraps: false },
+    { app: 'FaceTime', scheme: 'facetime://', example: 'facetime://+15551234567', platforms: ['macOS', 'iOS'], docs: null, wraps: true },
+]
+
+export const SCHEMES_BY_PREFIX = Object.fromEntries(
+    URL_SCHEMES.map(s => [s.scheme.replace(/[/:].*$/, ''), s])
+)


### PR DESCRIPTION
## Summary

Adds a new `/tools/` section with four interactive utilities, each targeting a distinct long-tail keyword cluster the homepage cannot rank for. Grows indexable surface from 3 pages to 8 (tools index + 4 tools + existing pages) and links every new page back to the main converter.

### Tools shipped

- **`/tools/url-compatibility-checker/`** — paste a URL, see a 9-platform × 9-scheme matrix of where it works, partially works, or breaks. Targets _"slack link broken in notion"_, _"why obsidian link doesn't work"_.
- **`/tools/deep-link-builder/`** — guided forms for Slack, Obsidian, Zoom, Notion, Figma, and a custom builder, producing both raw `scheme://` and Shortlink-wrapped HTTPS output. Targets _"obsidian deep link generator"_, _"slack:// builder"_.
- **`/tools/markdown-link-generator/`** — URL+label → 6 ready-to-paste formats (Markdown, Obsidian wikilink, Slack mrkdwn, HTML, RST, plain). Auto-detects custom schemes and offers one-toggle Shortlink wrapping. Targets _"markdown link generator"_, _"slack mrkdwn syntax"_.
- **`/tools/url-scheme-registry/`** — searchable reference of 50+ app URL schemes with example URLs and platform support. Targets _"list of url schemes"_, _"obsidian uri scheme"_.

### Architecture

- Each tool page is a **server component** so all SEO-relevant content (H1, FAQ Q&As, reference tables, geo blurbs) renders in initial HTML — indexable without JavaScript.
- Interactivity lives in **`'use client'` islands** under `components/tools/*-client.js`.
- Each page emits **WebApplication + FAQPage JSON-LD**.
- Geo content uses a **static-grid + JS-highlight** pattern: all 9 regional blurbs render statically (every variant is indexed), then a tiny client component reads the visitor's timezone and adds a "popular near you" badge to the matching one. No content is hidden from crawlers.
- Shared `ToolShell` provides breadcrumbs, related-tools cross-links, and a CTA back to the homepage converter on every tool page.

### Wiring

- `components/header.js` — adds "Tools" nav link site-wide.
- `app/page.js` — links from the supported-schemes section to the registry.
- `app/sitemap.js` — adds `/tools/` + 4 tool URLs (priority 0.8–0.9).

### What's deferred

Three more tools (Decoder, Compression Calculator, Embedding Quiz) from the original 7-tool plan are out of scope for this PR; separate plan to follow.

## Test plan

- [x] `npm test` — existing codec tests still pass (28/28)
- [x] `npx next build` — succeeds; all 4 tool pages prerender as static (●), bundle sizes 2.27 kB – 3.81 kB
- [ ] Manually visit `/tools/`, exercise each interactive widget (paste/build/copy/search)
- [ ] View source on each tool page → confirm H1, FAQ bodies, reference table, JSON-LD, canonical link present without JS
- [ ] Validate JSON-LD via Google Rich Results Test
- [ ] DevTools → override timezone to `Asia/Tokyo` → confirm Japan card gets "Popular near you" badge while all 9 stay visible
- [ ] Round-trip a generated Shortlink: build a `slack://` link in Tool 4, paste the wrapped URL into a fresh tab, confirm it decodes to the same target

https://claude.ai/code/session_01RJMT8DFgYomcd2dD8UjrfR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJMT8DFgYomcd2dD8UjrfR)_