### PR TITLE
feat: add SEO tool pages + UX bug fixes

### DIFF
--- a/app/tools/url-scheme-registry/page.js
+++ b/app/tools/url-scheme-registry/page.js
@@ -75,43 +75,8 @@ export default function UrlSchemeRegistryPage() {
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(webAppLd) }}
             />
 
-            {/* Searchable client table */}
             <section className="py-10">
-                <RegistryClient schemes={URL_SCHEMES} />
-            </section>
-
-            {/* Static fallback table — duplicates the data for crawlers regardless of JS */}
-            <section className="border-t border-zinc-800 py-10" aria-hidden="false">
-                <h2 className="font-display text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4">
-                    Full URL scheme reference
-                </h2>
-                <p className="text-zinc-500 text-sm mb-6 max-w-[60ch]">
-                    The complete list, also indexable without JavaScript. {wrappable} of {URL_SCHEMES.length} schemes can be wrapped into a universal HTTPS link via Shortlink.
-                </p>
-                <div className="overflow-x-auto border border-zinc-800">
-                    <table className="w-full font-mono text-xs">
-                        <thead>
-                            <tr className="bg-zinc-900 text-zinc-400 uppercase tracking-widest text-[10px]">
-                                <th className="text-left p-3 border-b border-zinc-800">App</th>
-                                <th className="text-left p-3 border-b border-zinc-800">Scheme</th>
-                                <th className="text-left p-3 border-b border-zinc-800 hidden md:table-cell">Example</th>
-                                <th className="text-left p-3 border-b border-zinc-800 hidden lg:table-cell">Platforms</th>
-                                <th className="text-left p-3 border-b border-zinc-800">Wraps?</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {URL_SCHEMES.map(s => (
-                                <tr key={'static-' + s.app + s.scheme} className="border-b border-zinc-900">
-                                    <td className="p-3 text-white">{s.app}</td>
-                                    <td className="p-3 text-emerald-500">{s.scheme}</td>
-                                    <td className="p-3 text-zinc-500 hidden md:table-cell truncate max-w-[280px]">{s.example}</td>
-                                    <td className="p-3 text-zinc-500 hidden lg:table-cell">{s.platforms.join(', ')}</td>
-                                    <td className="p-3">{s.wraps ? <span className="text-emerald-500">Yes</span> : <span className="text-zinc-600">No</span>}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+                <RegistryClient schemes={URL_SCHEMES} wrappable={wrappable} />
             </section>
 
             {/* Explainer sections */}

--- a/components/tools/checker-client.js
+++ b/components/tools/checker-client.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { PLATFORMS, check, extractScheme } from 'utils/data/platform-rules'
 
 const STATUS_STYLES = {
@@ -12,61 +12,45 @@ const STATUS_STYLES = {
 
 export default function CheckerClient() {
     const [input, setInput] = useState('')
-    const [scheme, setScheme] = useState('')
-    const [results, setResults] = useState(null)
 
-    const handleCheck = () => {
-        const detected = extractScheme(input)
-        setScheme(detected)
-        if (!detected) {
-            setResults(null)
-            return
-        }
-        setResults(PLATFORMS.map(p => check(detected, p)))
-    }
+    const scheme = useMemo(() => extractScheme(input), [input])
+    const results = useMemo(
+        () => (scheme ? PLATFORMS.map(p => check(scheme, p)) : null),
+        [scheme]
+    )
 
-    const handleSubmit = (e) => {
-        e.preventDefault()
-        handleCheck()
-    }
+    const trimmed = input.trim()
+    const showCannotDetect = trimmed.length >= 4 && !scheme
 
     return (
         <div className="space-y-6">
-            <form onSubmit={handleSubmit}>
+            <div>
                 <label htmlFor="checker-input" className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
                     Paste any URL
                 </label>
-                <div className="flex gap-px bg-zinc-800">
-                    <input
-                        id="checker-input"
-                        type="text"
-                        value={input}
-                        onChange={e => setInput(e.target.value)}
-                        autoCapitalize="off"
-                        autoComplete="off"
-                        autoCorrect="off"
-                        spellCheck="false"
-                        placeholder="slack://channel?team=T0001&id=C0001"
-                        className="flex-1 bg-zinc-900 border border-zinc-700 text-white font-mono text-base px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
-                    />
-                    <button
-                        type="submit"
-                        className="bg-emerald-600 hover:bg-emerald-500 active:scale-[0.98] text-white font-display font-bold py-3 px-6 text-xs tracking-wider uppercase transition-all whitespace-nowrap"
-                    >
-                        Check
-                    </button>
-                </div>
+                <input
+                    id="checker-input"
+                    type="text"
+                    value={input}
+                    onChange={e => setInput(e.target.value)}
+                    autoCapitalize="off"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    spellCheck="false"
+                    placeholder="slack://channel?team=T0001&id=C0001"
+                    className="w-full bg-zinc-900 border border-zinc-700 text-white font-mono text-base px-4 py-3 rounded-none placeholder:text-zinc-600 focus:outline-none focus:border-emerald-500 transition-colors"
+                />
                 {scheme && (
                     <div className="mt-3 font-mono text-xs text-zinc-500">
                         Detected scheme: <span className="text-emerald-500">{scheme}://</span>
                     </div>
                 )}
-                {input && !scheme && results === null && (
+                {showCannotDetect && (
                     <div className="mt-3 font-mono text-xs text-amber-400">
                         Could not detect a URL scheme. Try a URL like <code>slack://...</code>.
                     </div>
                 )}
-            </form>
+            </div>
 
             {results && (
                 <div>

--- a/components/tools/registry-client.js
+++ b/components/tools/registry-client.js
@@ -2,12 +2,11 @@
 
 import { useState, useMemo } from 'react'
 
-// Client island for the URL Scheme Registry. Renders the same table the
-// server already rendered, but with a search filter on top. The page server
-// component still renders the full static table for crawlers — this component
-// progressively replaces it once JS hydrates.
+// Client island for the URL Scheme Registry. Next.js SSRs this for the initial
+// HTML, so crawlers see every row without executing JS — search is a pure
+// progressive enhancement on top.
 
-export default function RegistryClient({ schemes }) {
+export default function RegistryClient({ schemes, wrappable }) {
     const [query, setQuery] = useState('')
 
     const filtered = useMemo(() => {
@@ -21,6 +20,11 @@ export default function RegistryClient({ schemes }) {
 
     return (
         <div className="space-y-5">
+            {typeof wrappable === 'number' && (
+                <p className="text-zinc-500 text-sm max-w-[60ch]">
+                    {wrappable} of {schemes.length} schemes can be wrapped into a universal HTTPS link via Shortlink.
+                </p>
+            )}
             <div>
                 <label className="font-mono text-[10px] uppercase tracking-widest text-zinc-500 block mb-2">
                     Search the registry


### PR DESCRIPTION
## Summary

- **Four new interactive tool pages** under `/tools/` targeting long-tail deep-link search traffic: URL Compatibility Checker, Deep Link Builder, Markdown Link Generator, and URL Scheme Registry (50+ app schemes)
- Each page is a Next.js server component with full SEO content (H1, FAQ, structured data, canonical) rendered in initial HTML; interactive widgets are `'use client'` islands
- Added `WebApplication` + `FAQPage` JSON-LD on every tool page; updated sitemap with 5 new entries; added "Tools" nav link in header
- **Bug fix:** URL Compatibility Checker was showing a false "Could not detect a URL scheme" warning before the user clicked submit — rewrote to live-eval via `useMemo` so results appear instantly as you type, no button needed
- **Bug fix:** URL Scheme Registry was rendering the full 50-row table twice (interactive client island + a redundant "static fallback"). Next.js SSRs client components into the initial HTML so the fallback was never needed; removed it and moved the "X of Y wrappable" summary into the client header

## Test plan

- [ ] Visit `/tools/url-compatibility-checker/` — type `slack://channel/ABC123` character by character; "Detected scheme: slack://" should appear as soon as `slack:` is typed, no button click needed
- [ ] Type `notaurl` on the same page — amber "Could not detect" warning appears after 4+ chars; clearing input removes it
- [ ] Visit `/tools/url-scheme-registry/` — confirm only ONE table is visible; "X of Y schemes can be wrapped" line appears above the search box
- [ ] `view-source:` on `/tools/url-scheme-registry/` — full registry table present in initial HTML (SSR confirmed)
- [ ] Visit `/tools/deep-link-builder/` and `/tools/markdown-link-generator/` — interactive widgets function correctly
- [ ] Check `/sitemap.xml` — 5 new tool URLs present
- [ ] `npm test` — 28 codec tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJMT8DFgYomcd2dD8UjrfR)_